### PR TITLE
runqemu: Search in $MACHINE sysroot for bios

### DIFF
--- a/scripts/runqemu
+++ b/scripts/runqemu
@@ -494,13 +494,13 @@ fi
 
 # Specify directory for BIOS, VGA BIOS and keymaps
 if [ ! -z "$CUSTOMBIOSDIR" ]; then
-    if [ -d "$OECORE_NATIVE_SYSROOT/$CUSTOMBIOSDIR" ]; then
-        echo "Assuming biosdir is $OECORE_NATIVE_SYSROOT/$CUSTOMBIOSDIR"
-        SCRIPT_QEMU_OPT="$SCRIPT_QEMU_OPT -L $OECORE_NATIVE_SYSROOT/$CUSTOMBIOSDIR"
+    if [ -d "$OE_TMPDIR/sysroots/$MACHINE/$CUSTOMBIOSDIR" ]; then
+        echo "Assuming biosdir is $OE_TMPDIR/sysroots/$MACHINE/$CUSTOMBIOSDIR"
+        SCRIPT_QEMU_OPT="$SCRIPT_QEMU_OPT -L $OE_TMPDIR/sysroots/$MACHINE/$CUSTOMBIOSDIR"
     else
         if [ ! -d "$CUSTOMBIOSDIR" ]; then
             echo "Custom BIOS directory not found. Tried: $CUSTOMBIOSDIR"
-            echo "and $OECORE_NATIVE_SYSROOT/$CUSTOMBIOSDIR"
+            echo "and $OE_TMPDIR/sysroots/$MACHINE/$CUSTOMBIOSDIR"
             exit 1;
         fi
         echo "Assuming biosdir is $CUSTOMBIOSDIR"


### PR DESCRIPTION
@ricardon could you take a look at this patch and see what you think? It basically makes biosdir="" work now that we've switched to building ovmf as a non-native recipe in commit f147459

commit "runqemu: Add option for custom BIOS directory" added a
biosdir="" option to runqemu which provides a shortcut for specifying a
path to a custom qemu bios (indirectly via qemu's -L option).

However, biosdir="" searches in $OE_NATIVE_SYSROOT for bios.bin, meaning
that the qemu bios recipe must be built as a native recipe. Arguably all
qemu firmware should be built as non-native because they're not executed
directly by the build machine.

Switch biosdir="" to search in $OE_TMPDIR/sysroots/$MACHINE, which is
the location of non-native files.

Cc: Ricardo Neri ricardo.neri-calderon@linux.intel.com
Signed-off-by: Matt Fleming matt.fleming@intel.com
