### PR TITLE
luv-live-image: Make luv-results the first partition

### DIFF
--- a/meta-luv/recipes-core/images/luv-live-image.bb
+++ b/meta-luv/recipes-core/images/luv-live-image.bb
@@ -51,16 +51,17 @@ build_img() {
 
     parted $IMG mklabel msdos
 
-    parted $IMG mkpart primary 0% "${VFAT_SIZE}B"
-    parted $IMG set 1 boot on
+    parted $IMG mkpart primary 0% "${VFAT_RESULTS_SIZE}B"
 
     # start second partition on the first sector after the first partition
-    parted $IMG mkpart primary "$(expr $VFAT_SIZE + 512)B" \
+    parted $IMG mkpart primary "$(expr $VFAT_RESULTS_SIZE + 512)B" \
            "$(expr $VFAT_SIZE + $VFAT_RESULTS_SIZE)B"
 
-    dd conv=notrunc if=${VFAT} of=$IMG seek=1 bs=512
+    parted $IMG set 2 boot on
 
-    dd if=${VFAT_RESULTS} of=$IMG seek=$(expr $VFAT_SIZE + 512) bs=1
+    dd conv=notrunc if=${VFAT_RESULTS} of=$IMG seek=1 bs=512
+    dd if=${VFAT} of=$IMG seek=$(expr $(expr $VFAT_RESULTS_SIZE / 512) + 1) bs=512
+
 }
 
 python do_create_img() {


### PR DESCRIPTION
Windows will not mount and display more than one partition on a
removable disk.

Make the results partiion the first partition on the image so that users
are able to easily find the test results. Having this one partition
restriction isn't a problem otherwise, since there's little value in
auto-mounting the other partition (the EFI System Partition) anyway.

Of course, we're assuming firmware is smart enough to find the EFI
System Partition based on the partition table.

Fixes issue #23.

Reported-by: William Leara williamleara@gmail.com
Debugged-by: Ricardo Neri ricardo.neri-calderon@linux.intel.com
Signed-off-by: Matt Fleming matt.fleming@intel.com
