### PR TITLE
recipes-devtools: Add uefi-firmware-parser Python module

### DIFF
--- a/meta-luv/classes/pypi.bbclass
+++ b/meta-luv/classes/pypi.bbclass
@@ -1,0 +1,30 @@
+def pypi_package(d):
+    bpn = d.getVar('BPN', True)
+    if bpn.startswith('python-'):
+        return bpn[7:]
+    elif bpn.startswith('python3-'):
+        return bpn[8:]
+    return bpn
+
+PYPI_PACKAGE ?= "${@pypi_package(d)}"
+PYPI_PACKAGE_EXT ?= "tar.gz"
+
+def pypi_src_uri(d):
+    package = d.getVar('PYPI_PACKAGE', True)
+    package_ext = d.getVar('PYPI_PACKAGE_EXT', True)
+    package_hash = d.getVar('PYPI_PACKAGE_HASH', True)
+    pv = d.getVar('PV', True)
+    if package_hash:
+        return 'https://pypi.python.org/packages/%s/%s/%s/%s-%s.%s' % (
+            package_hash[:2], package_hash[2:4], package_hash[4:], package, pv, package_ext)
+    else:
+        return 'https://pypi.python.org/packages/source/%s/%s/%s-%s.%s' % (
+            package[0], package, package, pv, package_ext)
+
+PYPI_SRC_URI ?= "${@pypi_src_uri(d)}"
+
+HOMEPAGE ?= "https://pypi.python.org/pypi/${PYPI_PACKAGE}/"
+SECTION = "devel/python"
+SRC_URI += "${PYPI_SRC_URI}"
+S = "${WORKDIR}/${PYPI_PACKAGE}-${PV}"
+

--- a/meta-luv/recipes-core/images/core-image-efi-initramfs.bb
+++ b/meta-luv/recipes-core/images/core-image-efi-initramfs.bb
@@ -11,7 +11,7 @@ IMAGE_INSTALL = "\
     "
 
 X86_ADDITIONS = "chipsec python-codecs python-subprocess kexec vmcore-dmesg bits \
-                 kernel-modules"
+                 kernel-modules uefi-firmware-parser"
 
 IMAGE_INSTALL_append_qemux86 = "${X86_ADDITIONS}"
 IMAGE_INSTALL_append_qemux86-64 = "${X86_ADDITIONS} ndctl"

--- a/meta-luv/recipes-devtools/uefi-firmware-parser/uefi-firmware-parser_1.6.bb
+++ b/meta-luv/recipes-devtools/uefi-firmware-parser/uefi-firmware-parser_1.6.bb
@@ -1,0 +1,12 @@
+SUMMARY = "Python module uefi-firmware for parsing/extracting UEFI structures"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://PKG-INFO;md5=18abe1c5026e14a25f210a99c232300e"
+
+DEPENDS = "python-dev"
+
+SRC_URI[md5sum] = "561cc83f9bf48f5c976398e47a3ba9df"
+SRC_URI[sha256sum] = "8c15f0406e8f9ea1b0d1d0e7107199cbaaa996b5cffdc1437789291adb81ce52"
+PYPI_PACKAGE_HASH = "9dcf4bfe2b207e214bfedc2f57ced8d4742fad2da70ec67db562ab023373daf8"
+
+PYPI_PACKAGE = "uefi_firmware"
+inherit pypi setuptools


### PR DESCRIPTION
I promised this a while back. ;)

In case anyone is wondering about the variances in naming:
- Recipe name: [`uefi-firmware-parser`](https://github.com/theopolis/uefi-firmware-parser) this is the project's name.
- PyPi module name: [`uefi_firmware`](https://pypi.python.org/pypi/uefi_firmware/1.6) this is what you import in `python -c 'import uefi_firmware'`.

This adds a `pypi` class, slightly modified from `meta-python`, which supports both name and hash-based source page downloading. PyPi seems to suggest the hash-bashed download from their S3 bucket so new packages should define a `PYPI_PACKAGE_HASH`. This is retrieved from the PyPi project page.

This recipe will install the python module for development but also a binary/entry-point (as documented on PyPi and the project README): `/usr/local/bin/uefi-firmware-parser`. The `/usr/local/` PREFIX is determined by `setuptools`.